### PR TITLE
Fix crash at job submission when --save_images=True

### DIFF
--- a/submit_jobs.py
+++ b/submit_jobs.py
@@ -163,7 +163,7 @@ def main():
             "--indir ./ --infile_list={infile_name}",
             "--max_events={}".format(switches["max_events"]),
             "--{mode}",
-            "--cam_ids",
+            "--cam_ids {}".format(cam_id_list),
         ]
         output_filename_template = "TRAINING"
     elif switches["output_type"] in "DL2":
@@ -179,7 +179,7 @@ def main():
             "--force_tailcut_for_extended_cleaning={}".format(
                 force_tailcut_for_extended_cleaning
             ),
-            "--cam_ids",
+            "--cam_ids {}".format(cam_id_list),
         ]
         output_filename_template = "DL2"
 
@@ -190,7 +190,7 @@ def main():
     cmd = [source_ctapipe, "&&", "./" + execute]
     cmd += script_args
 
-    pilot_args_write = " ".join(cmd + cam_id_list)
+    pilot_args_write = " ".join(cmd)
 
     # For table merging if multiple runs
     pilot_args_merge = " ".join(


### PR DESCRIPTION
`cam_id_list` was added at the end of the command, but the last command option is `--save_images` when this is set to `True`

now `cam_id_list` is read directly at `--cam_ids`, even though it's not really used by the pipeline anymore, in favor of the more customizable `array` entry in the analysis configuration file `analysis.yaml`