### PR TITLE
Upload analysis config for provenance

### DIFF
--- a/submit_jobs.py
+++ b/submit_jobs.py
@@ -603,6 +603,27 @@ def main():
     except:
         pass
 
+    # Upload analysis configuration file for provenance
+    
+    SE_LIST=['CC-IN2P3-USER', 'DESY-ZN-USER', 'CNAF-USER', 'CEA-USER']
+    analysis_config_local = os.path.join(config_path, config_file)
+    # the configuration file is uploaded to the data directory because
+    # the training samples (as well as their cleaning settings) are independent
+    analysis_config_dirac = os.path.join(home_grid, output_path, config_file)
+    print("Uploading {} to {}...".format(analysis_config_local, analysis_config_dirac))
+
+    if switches["dry"] is False:
+        # Upload this file to all Dirac Storage Elements in SE_LIST
+        for se in SE_LIST:
+            # the uploaded config file overwrites any old copy
+            ana_cfg_upload_cmd = "dirac-dms-add-file -f {} {} {}".format(
+                analysis_config_dirac, analysis_config_local, se
+            )
+            ana_cfg_upload_result = subprocess.check_output(ana_cfg_upload_cmd, shell=True)
+            print(ana_cfg_upload_result)
+    else:
+        print("This is a DRY RUN! -- analysis.yaml has NOT been uploaded.")
+
     print("\nall done -- exiting now")
     exit()
 


### PR DESCRIPTION
upload `analysis.yaml `each time `submit_jobs.py` is launched at the end of the jobs submission (so 1 YAML per batch)

The configuration file is stored under the data folder associated to the job type, i.e. one of the following under the analysis folder,

- `data/TRAINING/for_energy_estimation`
- `data/TRAINING/for_particle_classification`
- `data/DL2`

this allows to check a-posteriori with which settings the stored data was produced (even though the same file is stored in the local analysis folder of the user)

The storage under the data folder accounts also for the fact that the training cleanings could be different (e.g. looser for particle classification, stricter for energy estimation) - in that case it would make sense that also the local directory stores it in the same way.