### PR TITLE
Fix inconsistency between different use-cases

### DIFF
--- a/create_analysis_tree.py
+++ b/create_analysis_tree.py
@@ -110,7 +110,7 @@ using the protopipe prototype pipeline.
     
     parser.add_argument(
         "--output_path", type=str, default=os.environ['HOME'],
-        help="Full path to the folder which contain analyses and productions (default: home directory)"
+        help="Full path of the folder containing analyses and productions (default: home directory)"
     )
 
     parser.add_argument(

--- a/create_analysis_tree.py
+++ b/create_analysis_tree.py
@@ -102,6 +102,16 @@ using the protopipe prototype pipeline.
     parser.add_argument(
         "--analysis_name", type=str, required=True, help="Name of the analysis"
     )
+    
+    parser.add_argument(
+        "--source_path", type=str, default=os.environ['HOME'],
+        help="Path to the source codes of protopipe and the GRID interface (default: home directory)"
+    )
+    
+    parser.add_argument(
+        "--output_path", type=str, default=os.environ['HOME'],
+        help="Path of the folder which will contain analyses and productions (default: home directory)"
+    )
 
     parser.add_argument(
         "--GRID-is-DIRAC", action='store_true', help="The grid on which to run the analysis is the DIRAC grid."
@@ -120,12 +130,9 @@ using the protopipe prototype pipeline.
     # read command-line arguments
     analysis_name = args.analysis_name
 
-    # Get home's absolute path
-    home_path = os.environ['HOME']
-
     # Define required directories and create them if necessary
 
-    shared_folder_directory = os.path.join(home_path, "shared_folder")
+    shared_folder_directory = os.path.join(args.output_path, "shared_folder")
     makedir(shared_folder_directory)
 
     analyses_directory = os.path.join(shared_folder_directory, "analyses")
@@ -166,8 +173,8 @@ using the protopipe prototype pipeline.
         logging.info("Directory structure ready for protopipe analysis.")
 
         # Source code paths
-        interface_path = os.path.join(home_path, "protopipe-grid-interface")
-        protopipe_path = os.path.join(home_path, "protopipe")
+        interface_path = os.path.join(args.source_path, "protopipe-grid-interface")
+        protopipe_path = os.path.join(args.source_path, "protopipe")
         protopipe_configs = os.path.join(
             protopipe_path, "protopipe/aux/example_config_files/"
         )
@@ -176,20 +183,24 @@ using the protopipe prototype pipeline.
         
         setup_config(os.path.join(interface_path, "download_and_merge.sh"),
                      os.path.join(analysis_path, "data/download_and_merge.sh"),
-                     ['ANALYSIS_NAME=""',
+                     ['LOCAL=""',
+                      'ANALYSIS_NAME=""',
                       'HOME_PATH_GRID=""',
                       'ANALYSIS_PATH_GRID=""'],
-                     ['ANALYSIS_NAME="{}"'.format(analysis_name),
+                     ['LOCAL="{}"'.format(args.output_path),
+                      'ANALYSIS_NAME="{}"'.format(analysis_name),
                       'HOME_PATH_GRID="{}"'.format(args.GRID_home),
                       'ANALYSIS_PATH_GRID="{}"'.format(args.GRID_path_from_home)]
                      )
         
         setup_config(os.path.join(interface_path, "upload_models.sh"),
                      os.path.join(analysis_path, "estimators/upload_models.sh"),
-                     ['ANALYSIS_NAME=""',
+                     ['LOCAL=""',
+                      'ANALYSIS_NAME=""',
                       'HOME_PATH_GRID=""',
                       'ANALYSIS_PATH_GRID=""'],
-                     ['ANALYSIS_NAME="{}"'.format(analysis_name),
+                     ['LOCAL="{}"'.format(args.output_path),
+                      'ANALYSIS_NAME="{}"'.format(analysis_name),
                       'HOME_PATH_GRID="{}"'.format(args.GRID_home),
                       'ANALYSIS_PATH_GRID="{}"'.format(args.GRID_path_from_home)]
                      )
@@ -202,12 +213,12 @@ using the protopipe prototype pipeline.
         setup_config(os.path.join(interface_path, "grid.yaml"),
                      os.path.join(analysis_path, "configs/grid.yaml"),
                      ["$ANALYSIS_NAME",
-                      "$HOME",
+                      "$LOCAL",
                       "user_name: ''",
                       "home_grid: ''",
                       "outdir: ''"],
                      [analysis_name,
-                      home_path,
+                      args.output_path,
                       "user_name: '{}'".format(username),
                       "home_grid: '{}'".format(args.GRID_home),
                       "outdir: '{}'".format(args.GRID_path_from_home)

--- a/create_analysis_tree.py
+++ b/create_analysis_tree.py
@@ -110,7 +110,7 @@ using the protopipe prototype pipeline.
     
     parser.add_argument(
         "--output_path", type=str, default=os.environ['HOME'],
-        help="Full path of the folder which will contain analyses and productions (default: home directory)"
+        help="Full path to the folder which contain analyses and productions (default: home directory)"
     )
 
     parser.add_argument(

--- a/create_analysis_tree.py
+++ b/create_analysis_tree.py
@@ -105,12 +105,12 @@ using the protopipe prototype pipeline.
     
     parser.add_argument(
         "--source_path", type=str, default=os.environ['HOME'],
-        help="Path to the source codes of protopipe and the GRID interface (default: home directory)"
+        help="Full path to the source codes of protopipe and the GRID interface (default: home directory)"
     )
     
     parser.add_argument(
         "--output_path", type=str, default=os.environ['HOME'],
-        help="Path of the folder which will contain analyses and productions (default: home directory)"
+        help="Full path of the folder which will contain analyses and productions (default: home directory)"
     )
 
     parser.add_argument(
@@ -233,11 +233,16 @@ using the protopipe prototype pipeline.
                      )
 
         # Same with the benchmarks configuration file
-        setup_config(os.path.join(protopipe_configs, "benchmarks.yaml"),
-                     os.path.join(analysis_path, "configs/benchmarks.yaml"),
-                     ["analysis_name: ''"],
-                     ["analysis_name: '{}'".format(analysis_name)]
-                     )
+        try:
+            setup_config(os.path.join(protopipe_configs, "benchmarks.yaml"),
+                         os.path.join(analysis_path, "configs/benchmarks.yaml"),
+                         ["analysis_name: ''"],
+                         ["analysis_name: '{}'".format(analysis_name)]
+                         )
+        except IOError:
+            print("benchmarks.yaml not found in example configs")
+            print("You should find it under docs/contribute/benchmarks")
+            pass
 
         # copy all other configuration files
         # these will require to work outside of the container untile CTADIRAC supports Python3

--- a/create_analysis_tree.py
+++ b/create_analysis_tree.py
@@ -229,10 +229,8 @@ using the protopipe prototype pipeline.
         # Same with the analysis configuration file
         setup_config(os.path.join(protopipe_configs, "analysis.yaml"),
                      os.path.join(analysis_path, "configs/analysis.yaml"),
-                     ["analyses_directory: ''",
-                      "config_name: ''"],
-                     ["analyses_directory: '{}'".format(analysis_path),
-                      "config_name: '{}'".format(analysis_name)]
+                     ["config_name: ''"],
+                     ["config_name: '{}'".format(analysis_name)]
                      )
 
         # Same with the benchmarks configuration file

--- a/create_analysis_tree.py
+++ b/create_analysis_tree.py
@@ -254,7 +254,7 @@ using the protopipe prototype pipeline.
                 config_file, os.path.join(analysis_path, "configs")
             )
 
-        logging.info("Auxiliary scripts and configuration file are also stored there.")
+        logging.info("Auxiliary scripts and configuration files have been stored and partially filled.")
 
     else:
         logging.info("Required analysis folder already present. For safety no sub-directory will be overwritten.")

--- a/create_analysis_tree.py
+++ b/create_analysis_tree.py
@@ -8,6 +8,7 @@ from argparse import RawTextHelpFormatter
 import shutil
 import logging
 
+logging.basicConfig(level=logging.INFO)
 
 def setup_config(input_file, output_file, old_text, new_text):
     """Fill a configuration file for an analysis starting from the example one.

--- a/create_analysis_tree.py
+++ b/create_analysis_tree.py
@@ -228,8 +228,10 @@ using the protopipe prototype pipeline.
         # Same with the analysis configuration file
         setup_config(os.path.join(protopipe_configs, "analysis.yaml"),
                      os.path.join(analysis_path, "configs/analysis.yaml"),
-                     ["config_name: ''"],
-                     ["config_name: '{}'".format(analysis_name)]
+                     ["analyses_directory: ''",
+                      "config_name: ''"],
+                     ["analyses_directory: '{}'".format(analysis_path),
+                      "config_name: '{}'".format(analysis_name)]
                      )
 
         # Same with the benchmarks configuration file

--- a/create_analysis_tree.py
+++ b/create_analysis_tree.py
@@ -241,8 +241,8 @@ using the protopipe prototype pipeline.
                          ["analysis_name: '{}'".format(analysis_name)]
                          )
         except IOError:
-            print("benchmarks.yaml not found in example configs")
-            print("You should find it under docs/contribute/benchmarks")
+            logging.warning("benchmarks.yaml not found in example configs")
+            logging.warning("You should find it under docs/contribute/benchmarks")
             pass
 
         # copy all other configuration files

--- a/download_and_merge.sh
+++ b/download_and_merge.sh
@@ -45,7 +45,7 @@ for part in $PARTICLE; do
 
   # Download files
   echo "Downloading $part..."
-  $DIRAC/diracos/usr/bin $GRID_INTERFACE/download_files.py --indir="$INPUT_DIR" --outdir="$OUTPUT_DIR"
+  $DIRAC/diracos/usr/bin/python $GRID_INTERFACE/download_files.py --indir="$INPUT_DIR" --outdir="$OUTPUT_DIR"
 
   # Merge files
   echo "Merging $part..."
@@ -54,6 +54,6 @@ for part in $PARTICLE; do
   echo "$OUTPUT_DIR"
   echo "$TEMPLATE_FILE_NAME"
   echo "$OUTPUT_FILE"
-  $DIRAC/diracos/usr/bin $GRID_INTERFACE/merge_tables.py --indir="$OUTPUT_DIR" --template_file_name="$TEMPLATE_FILE_NAME" --outfile="$OUTPUT_FILE"
+  $DIRAC/diracos/usr/bin/python $GRID_INTERFACE/merge_tables.py --indir="$OUTPUT_DIR" --template_file_name="$TEMPLATE_FILE_NAME" --outfile="$OUTPUT_FILE"
 
 done

--- a/download_and_merge.sh
+++ b/download_and_merge.sh
@@ -4,12 +4,12 @@
 #           EDIT ONLY THIS PART
 # ============================================
 
-# ANALYSIS STEP DATA PATH
+# ANALYSIS STEP DATA TYPE
 # Possible choices are,
 # - TRAINING/for_energy_estimation
 # - TRAINING/for_particle_classification
 # - DL2
-DATA_PATH=""
+DATA_TYPE=""
 
 PARTICLE=""  # This can be list up to "gamma proton electron"
 
@@ -20,18 +20,18 @@ PARTICLE=""  # This can be list up to "gamma proton electron"
 MODE="tail"  # also "wave" (wavelet) cleaning, but disabled for the moment
 
 # GRID environment variables
-GRID="$HOME/protopipe-grid-interface"
 HOME_PATH_GRID=""
 ANALYSIS_PATH_GRID=""
 
 # ANALYSIS environment variables
+LOCAL=""
 ANALYSIS_NAME=""
-ANALYSIS_PATH_LOCAL="$HOME/shared_folder/analyses/$ANALYSIS_NAME"
+ANALYSIS_PATH_LOCAL="$LOCAL/shared_folder/analyses/$ANALYSIS_NAME"
 
 # DIRAC file catalog full path
-INPUT_DIR="$HOME_PATH_GRID/$ANALYSIS_PATH_GRID/$ANALYSIS_NAME/data/$DATA_PATH"
+INPUT_DIR="$HOME_PATH_GRID/$ANALYSIS_PATH_GRID/$ANALYSIS_NAME/data/$DATA_TYPE"
 # Full path in local virtual environment for the grid interface
-OUTPUT_DIR="$ANALYSIS_PATH_LOCAL/data/$DATA_PATH/"
+OUTPUT_DIR="$ANALYSIS_PATH_LOCAL/data/$DATA_TYPE/"
 
 # FILE TYPE
 case $DATA_PATH in
@@ -45,7 +45,7 @@ for part in $PARTICLE; do
 
   # Download files
   echo "Downloading $part..."
-  python $GRID/download_files.py --indir="$INPUT_DIR" --outdir="$OUTPUT_DIR"
+  $DIRAC/diracos/usr/bin $GRID_INTERFACE/download_files.py --indir="$INPUT_DIR" --outdir="$OUTPUT_DIR"
 
   # Merge files
   echo "Merging $part..."
@@ -54,6 +54,6 @@ for part in $PARTICLE; do
   echo "$OUTPUT_DIR"
   echo "$TEMPLATE_FILE_NAME"
   echo "$OUTPUT_FILE"
-  python $GRID/merge_tables.py --indir="$OUTPUT_DIR" --template_file_name="$TEMPLATE_FILE_NAME" --outfile="$OUTPUT_FILE"
+  $DIRAC/diracos/usr/bin $GRID_INTERFACE/merge_tables.py --indir="$OUTPUT_DIR" --template_file_name="$TEMPLATE_FILE_NAME" --outfile="$OUTPUT_FILE"
 
 done

--- a/grid.yaml
+++ b/grid.yaml
@@ -1,7 +1,6 @@
 General:
  # Path to the analysis configuration file
- # You only need to edit the name of the analysis
- config_path: '$HOME/shared_folder/analyses/$ANALYSIS_NAME/configs/'
+ config_path: '$LOCAL/shared_folder/analyses/$ANALYSIS_NAME/configs/'
  # Name of the configuration file for the protopipe analysis
  config_file: 'analysis.yaml'
 
@@ -68,17 +67,17 @@ GRID:
 EnergyRegressor:
  # Events used to train an energy regressor
  # Used when output_type = TRAINING and estimate_energy is False
- gamma_list: '$HOME/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_gamma_South_20deg_DL0_TRAINING_ENERGY.list'
+ gamma_list: '$OUTDIR/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_gamma_South_20deg_DL0_TRAINING_ENERGY.list'
 
 GammaHadronClassifier:
  # Events used to train a gamma-hadron classifier
  # Used when output_type = TRAINING and estimate_energy is True
- gamma_list: '$HOME/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_gamma_South_20deg_DL0_TRAINING_CLASSIFICATION.list'
- proton_list: '$HOME/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_proton_South_20deg_DL0_TRAINING_CLASSIFICATION.list'
+ gamma_list: '$OUTDIR/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_gamma_South_20deg_DL0_TRAINING_CLASSIFICATION.list'
+ proton_list: '$OUTDIR/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_proton_South_20deg_DL0_TRAINING_CLASSIFICATION.list'
 
 Performance:
  # Events processed directly up to DL2 for DL3 production
  # Used when output_type = DL2
- gamma_list: '$HOME/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_gamma_South_20deg_DL0_PERFORMANCE.list'
- proton_list: '$HOME/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_proton_South_20deg_DL0_PERFORMANCE.list'
- electron_list: '$HOME/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_electron_South_20deg_DL0_PERFORMANCE.list'
+ gamma_list: '$OUTDIR/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_gamma_South_20deg_DL0_PERFORMANCE.list'
+ proton_list: '$OUTDIR/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_proton_South_20deg_DL0_PERFORMANCE.list'
+ electron_list: '$OUTDIR/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_electron_South_20deg_DL0_PERFORMANCE.list'

--- a/grid.yaml
+++ b/grid.yaml
@@ -67,17 +67,17 @@ GRID:
 EnergyRegressor:
  # Events used to train an energy regressor
  # Used when output_type = TRAINING and estimate_energy is False
- gamma_list: '$OUTDIR/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_gamma_South_20deg_DL0_TRAINING_ENERGY.list'
+ gamma_list: '$LOCAL/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_gamma_South_20deg_DL0_TRAINING_ENERGY.list'
 
 GammaHadronClassifier:
  # Events used to train a gamma-hadron classifier
  # Used when output_type = TRAINING and estimate_energy is True
- gamma_list: '$OUTDIR/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_gamma_South_20deg_DL0_TRAINING_CLASSIFICATION.list'
- proton_list: '$OUTDIR/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_proton_South_20deg_DL0_TRAINING_CLASSIFICATION.list'
+ gamma_list: '$LOCAL/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_gamma_South_20deg_DL0_TRAINING_CLASSIFICATION.list'
+ proton_list: '$LOCAL/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_proton_South_20deg_DL0_TRAINING_CLASSIFICATION.list'
 
 Performance:
  # Events processed directly up to DL2 for DL3 production
  # Used when output_type = DL2
- gamma_list: '$OUTDIR/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_gamma_South_20deg_DL0_PERFORMANCE.list'
- proton_list: '$OUTDIR/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_proton_South_20deg_DL0_PERFORMANCE.list'
- electron_list: '$OUTDIR/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_electron_South_20deg_DL0_PERFORMANCE.list'
+ gamma_list: '$LOCAL/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_gamma_South_20deg_DL0_PERFORMANCE.list'
+ proton_list: '$LOCAL/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_proton_South_20deg_DL0_PERFORMANCE.list'
+ electron_list: '$LOCAL/shared_folder/analyses/$ANALYSIS_NAME/data/simtel/Prod3_LaPalma_Baseline_NSB1x_electron_South_20deg_DL0_PERFORMANCE.list'

--- a/setup.sh
+++ b/setup.sh
@@ -14,6 +14,11 @@ GRID_INTERFACE_full_path=$(realpath $BASH_SOURCE)
 export GRID_INTERFACE=$(dirname $GRID_INTERFACE_full_path)
 echo "\$GRID_INTERFACE points to $GRID_INTERFACE"
 
+# Define where the source code of protopipe is stored
+# Same folder as the interface (as per installation instructions)
+export PROTOPIPE=$(dirname $GRID_INTERFACE)
+echo "\$PROTOPIPE points to $PROTOPIPE"
+
 # Check if DIRAC has been initialized
 if [[ -z "${DIRAC}" ]]; then
   echo "ERROR: \$DIRAC environment variable undefined!"

--- a/setup.sh
+++ b/setup.sh
@@ -30,3 +30,5 @@ if [ "$(command -v dirac-info)" != "$DIRAC/scripts/dirac-info" ]; then
     echo "Please, make sure that DIRAC has been properly installed."
     return 1
 fi
+
+echo "The protopipe GRID interface is ready to be used!"

--- a/setup.sh
+++ b/setup.sh
@@ -1,18 +1,32 @@
 #!/bin/bash
 
+# This is somewhat OP, since macos users will likely use the Docker container
+# were 'realpath' is defined, but just in case...
+if [[ ( "$OSTYPE" == "darwin"* ) && ( -z "$(command -v realpath)" ) ]]; then
+  echo "ERROR: realpath command not found!"
+  echo "You can install it with Homebrew: 'brew install coreutils'"
+  return 1
+fi
+
+# Define where the source code for the interface resides
+# This corresponds to where the setup.sh is located
 GRID_INTERFACE_full_path=$(realpath $BASH_SOURCE)
 export GRID_INTERFACE=$(dirname $GRID_INTERFACE_full_path)
 echo "\$GRID_INTERFACE points to $GRID_INTERFACE"
 
+# Check if DIRAC has been initialized
 if [[ -z "${DIRAC}" ]]; then
   echo "ERROR: \$DIRAC environment variable undefined!"
   echo "Please, make sure that DIRAC has been installed and initialized."
+  return 1
 else
   $DIRAC/diracos/usr/bin/pip install -r "$GRID_INTERFACE/requirements.txt"
 fi
 
-# check if dirac has been initialized
+# This should be also OP, but it can be that the installation has been
+# done in an incorrect way and the scripts are not where they shoud be
 if [ "$(command -v dirac-info)" != "$DIRAC/scripts/dirac-info" ]; then
     echo "ERROR: DIRAC scripts not accessible."
     echo "Please, make sure that DIRAC has been properly installed."
+    return 1
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,20 @@
 #!/bin/bash
-export INTERFACE="$HOME/protopipe-grid-interface"
-export PROTOPIPE="$HOME/protopipe"
-pip install -r "$INTERFACE/requirements.txt"
+
+GRID_INTERFACE_full_path=$(realpath $BASH_SOURCE)
+export GRID_INTERFACE=$(dirname $GRID_INTERFACE_full_path)
+echo "\$GRID_INTERFACE points to $GRID_INTERFACE"
+
+if [[ -z "${DIRAC}" ]]; then
+  echo "ERROR: DIRAC is not installed or it has not being installed properly."
+  echo "\$DIRAC environment variable undefined"
+  exit
+else
+  $DIRAC/diracos/usr/bin/pip install -r "$GRID_INTERFACE/requirements.txt"
+fi
+
+# check if dirac has been initialized
+if [ "$(command -v dirac-info)" != "$DIRAC/scripts/dirac-info" ]; then
+    echo "ERROR: DIRAC is not installed or it has not being installed properly."
+    echo "Command 'dirac-info' could not be found or it is not where is should be..."
+    exit
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -16,7 +16,7 @@ echo "\$GRID_INTERFACE points to $GRID_INTERFACE"
 
 # Define where the source code of protopipe is stored
 # Same folder as the interface (as per installation instructions)
-export PROTOPIPE=$(dirname $GRID_INTERFACE)
+export PROTOPIPE="$(dirname $GRID_INTERFACE)/protopipe"
 echo "\$PROTOPIPE points to $PROTOPIPE"
 
 # Check if DIRAC has been initialized

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@
 # were 'realpath' is defined, but just in case...
 if [[ ( "$OSTYPE" == "darwin"* ) && ( -z "$(command -v realpath)" ) ]]; then
   echo "ERROR: realpath command not found!"
-  echo "You can install it with Homebrew: 'brew install coreutils'"
+  echo "Please, check that you are using the Docker container."
   return 1
 fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -5,16 +5,14 @@ export GRID_INTERFACE=$(dirname $GRID_INTERFACE_full_path)
 echo "\$GRID_INTERFACE points to $GRID_INTERFACE"
 
 if [[ -z "${DIRAC}" ]]; then
-  echo "ERROR: DIRAC is not installed or it has not being installed properly."
-  echo "\$DIRAC environment variable undefined"
-  exit
+  echo "ERROR: \$DIRAC environment variable undefined!"
+  echo "Please, make sure that DIRAC has been installed and initialized."
 else
   $DIRAC/diracos/usr/bin/pip install -r "$GRID_INTERFACE/requirements.txt"
 fi
 
 # check if dirac has been initialized
 if [ "$(command -v dirac-info)" != "$DIRAC/scripts/dirac-info" ]; then
-    echo "ERROR: DIRAC is not installed or it has not being installed properly."
-    echo "Command 'dirac-info' could not be found or it is not where is should be..."
-    exit
+    echo "ERROR: DIRAC scripts not accessible."
+    echo "Please, make sure that DIRAC has been properly installed."
 fi

--- a/submit_jobs.py
+++ b/submit_jobs.py
@@ -27,7 +27,7 @@ Script.setUsageMessage(
         ]
     )
 )
-Script.registerSwitch("", "analysis_name=", "Name of the analysis")
+Script.registerSwitch("", "analysis_path=", "Full path to the analysis folder")
 Script.registerSwitch("", "output_type=", "Output data type (TRAINING or DL2)")
 Script.registerSwitch(
     "", "max_events=", "Max number of events to be processed (optional, int)"
@@ -51,8 +51,8 @@ from DIRAC.Interfaces.API.Job import Job
 from DIRAC.Interfaces.API.Dirac import Dirac
 
 # Control switches
-if switches.has_key("analysis_name") is False:
-    print("Analysis name argument is missing: --analysis_name")
+if switches.has_key("analysis_path") is False:
+    print("Analysis full path argument is missing: --analysis_path")
     sys.exit()
 
 if switches.has_key("output_type") is False:
@@ -119,12 +119,9 @@ def main():
         sys.exit()
 
     # Read configuration file
-    analysis_path = os.path.expanduser(os.path.join("~/shared_folder/analyses",
-                                                    switches["analysis_name"])
-                                      )
-    if not os.path.isdir(analysis_path):
+    if not os.path.isdir(switches["analysis_path"]):
         raise ValueError("This analysis folder doesn't exist yet - use create_analysis_tree.py")
-    cfg = load_config(os.path.join(analysis_path, "configs/grid.yaml"))
+    cfg = load_config(os.path.join(switches["analysis_path"], "configs/grid.yaml"))
 
     # Analysis
     config_path = cfg["General"]["config_path"]

--- a/submit_jobs.py
+++ b/submit_jobs.py
@@ -21,9 +21,9 @@ Script.setUsageMessage(
     "\n".join(
         [
             "Usage:",
-            "python $INTERFACE/%s.py [options]" % Script.scriptName,
+            "python $GRID_INTERFACE/%s.py [options]" % Script.scriptName,
             "e.g.:",
-            "python $INTERFACE/%s.py --analysis_name=test --output_type=DL2" % Script.scriptName,
+            "python $GRID_INTERFACE/%s.py --analysis_name=test --output_type=DL2" % Script.scriptName,
         ]
     )
 )
@@ -277,9 +277,9 @@ def main():
     # if file name starts with `LFN:`, it will be copied from the GRID
     input_sandbox = [
         # Utility to assign one job to one command...
-        os.path.expandvars("$INTERFACE/pilot.sh"),
+        os.path.expandvars("$GRID_INTERFACE/pilot.sh"),
         os.path.expandvars("$PROTOPIPE/protopipe/"),
-        os.path.expandvars("$INTERFACE/merge_tables.py"),
+        os.path.expandvars("$GRID_INTERFACE/merge_tables.py"),
         # python wrapper for the mr_filter wavelet cleaning
         # os.path.expandvars("$PYWI/pywi/"),
         # os.path.expandvars("$PYWICTA/pywicta/"),

--- a/submit_jobs.py
+++ b/submit_jobs.py
@@ -23,7 +23,7 @@ Script.setUsageMessage(
             "Usage:",
             "python $GRID_INTERFACE/%s.py [options]" % Script.scriptName,
             "e.g.:",
-            "python $GRID_INTERFACE/%s.py --analysis_name=test --output_type=DL2" % Script.scriptName,
+            "python $GRID_INTERFACE/%s.py --analysis_path=shared_folder/analyses/test --output_type=DL2" % Script.scriptName,
         ]
     )
 )

--- a/upload_models.sh
+++ b/upload_models.sh
@@ -43,8 +43,8 @@ for cam_id in $CAM_IDS; do
     config="${MODEL_NAME}.yaml"
     file="${MODEL_TYPE}_${cam_id}_${MODEL_NAME}.pkl.gz"
 
-    $DIRAC/diracos/usr/bin $GRID_INTERFACE/upload_file.py --indir=$CONFIG_DIR --infile=$config --outdir=$OUTPUT_DIR
-    $DIRAC/diracos/usr/bin $GRID_INTERFACE/upload_file.py --indir=$INPUT_DIR --infile=$file --outdir=$OUTPUT_DIR
+    $DIRAC/diracos/usr/bin/python $GRID_INTERFACE/upload_file.py --indir=$CONFIG_DIR --infile=$config --outdir=$OUTPUT_DIR
+    $DIRAC/diracos/usr/bin/python $GRID_INTERFACE/upload_file.py --indir=$INPUT_DIR --infile=$file --outdir=$OUTPUT_DIR
 
     # Make replicas
     for SE in $SE_LIST; do

--- a/upload_models.sh
+++ b/upload_models.sh
@@ -24,13 +24,13 @@ else
 fi
 
 # GRID environment variables
-GRID="$HOME/protopipe-grid-interface"
 HOME_PATH_GRID=""
 ANALYSIS_PATH_GRID=""
 
 # ANALYSIS environment variables
+LOCAL="" # Parent directory containing the 'shared_folder'
 ANALYSIS_NAME=""  # Name of the analysis
-ANALYSES_PATH="$HOME/shared_folder/analyses"
+ANALYSES_PATH="$LOCAL/shared_folder/analyses"
 CONFIG_DIR="$ANALYSES_PATH/$ANALYSIS_NAME/configs"
 INPUT_DIR="$ANALYSES_PATH/$ANALYSIS_NAME/estimators/$MODEL_TYPE_FOLDER"
 # DIRAC file catalog path
@@ -43,8 +43,8 @@ for cam_id in $CAM_IDS; do
     config="${MODEL_NAME}.yaml"
     file="${MODEL_TYPE}_${cam_id}_${MODEL_NAME}.pkl.gz"
 
-    python $GRID/upload_file.py --indir=$CONFIG_DIR --infile=$config --outdir=$OUTPUT_DIR
-    python $GRID/upload_file.py --indir=$INPUT_DIR --infile=$file --outdir=$OUTPUT_DIR
+    $DIRAC/diracos/usr/bin $GRID_INTERFACE/upload_file.py --indir=$CONFIG_DIR --infile=$config --outdir=$OUTPUT_DIR
+    $DIRAC/diracos/usr/bin $GRID_INTERFACE/upload_file.py --indir=$INPUT_DIR --infile=$file --outdir=$OUTPUT_DIR
 
     # Make replicas
     for SE in $SE_LIST; do


### PR DESCRIPTION
### Summary

This PR fixes the inconsistency in the use of the interface between solutions involving the CTADIRAC Docker container and those relying on less restrictive conditions (native installation on Linux machines and Singularity container)

- `create_analysis_tree.py` now accepts 2 new arguments which specify where is the source code (protopipe+interface) and where the `shared_folder` will be placed (I decided to keep the name for now)
- the setup script has been improved to check for the existence of a correct installation of DIRAC and if OK initialize some environment variables that fix the problem of where it is installed depending on the use-case
- all config files and scripts that are filled automatically by the interface at the creation of a new analysis have been updated accordingly

### TODO

Launch a batch a few 1-simtel jobs at TRAINING level and upload energy models to test all the operations

- [x] test from Linux
- [x] test from Singularity container
- [x] test from Docker