### PR TITLE
Fix extraction of run numbers

### DIFF
--- a/submit_jobs.py
+++ b/submit_jobs.py
@@ -517,7 +517,7 @@ def main():
         j.setInputData(bunch)
 
         for run_file in bunch:
-            file_token = re.split("_", run_file)[3]
+            file_token = re.split("/", bunch[0])[-1].split("_")[3]
 
             # wait for a random number of seconds (up to five minutes) before
             # starting to add a bit more entropy in the starting times of the


### PR DESCRIPTION
Bug discovered using Prod5b data files which path contained an additional splitting character that changed the result to another string.

Now splitting first by backslashes to get the simtel file, then underscores.

Still not straightforward to automatize without knowing in advance the patterns of the file paths stored on the grid.
