### PR TITLE
fixed logging error

### DIFF
--- a/protopipe_grid_interface/scripts/split_dataset.py
+++ b/protopipe_grid_interface/scripts/split_dataset.py
@@ -139,7 +139,7 @@ Default is [100]",
             numlines.append(numlines[-1] + delta)
 
         if len(numlines) != 1:
-            log.debug("Splitted according to file # : %i", numlines)
+            log.debug("Split according to file # : %s", numlines)
         else:
             log.debug("All files in 1 list.")
 


### PR DESCRIPTION
changed %i to %s, since numlines is a list not an integer


this fixes the following crash:
```
--- Logging error ---
Traceback (most recent call last):
  File "/Users/kkosack/miniconda3/envs/protopipe-CTADIRAC-dev/lib/python3.8/logging/__init__.py", line 1085, in emit
    msg = self.format(record)
  File "/Users/kkosack/miniconda3/envs/protopipe-CTADIRAC-dev/lib/python3.8/logging/__init__.py", line 929, in format
    return fmt.format(record)
  File "/Users/kkosack/miniconda3/envs/protopipe-CTADIRAC-dev/lib/python3.8/logging/__init__.py", line 668, in format
    record.message = record.getMessage()
  File "/Users/kkosack/miniconda3/envs/protopipe-CTADIRAC-dev/lib/python3.8/logging/__init__.py", line 373, in getMessage
    msg = msg % self.args
TypeError: %i format: a number is required, not list
Call stack:
  File "/Users/kkosack/miniconda3/envs/protopipe-CTADIRAC-dev/bin/protopipe-SPLIT_DATASET", line 33, in <module>
    sys.exit(load_entry_point('protopipe-grid-interface', 'console_scripts', 'protopipe-SPLIT_DATASET')())
  File "/Users/kkosack/Projects/CTA/Working/protopipe-grid-interface/protopipe_grid_interface/scripts/split_dataset.py", line 142, in main
    log.debug("Splitted according to file # : %i", numlines)
Message: 'Splitted according to file # : %i'
Arguments: ([0, 496, 992],)
```