### PR TITLE
Fix git syntax error in Dockerfile release version

### DIFF
--- a/containers/Docker/Release/Dockerfile
+++ b/containers/Docker/Release/Dockerfile
@@ -53,7 +53,7 @@ RUN echo ". $CONDA_DIR/etc/profile.d/conda.sh" >> ~/.profile \
 # WARNING: in the final Dockerfile the pull must come from either the
 # master branch (development version) or from a tagged release (released version)
 WORKDIR /home/cta/protopipe-grid-interface
-RUN git clone https://github.com/HealthyPear/protopipe-grid-interface.git \
+RUN git clone https://github.com/HealthyPear/protopipe-grid-interface.git .\
     && git fetch --tags \
     && latestTag=$(git describe --tags `git rev-list --tags --max-count=1`) \
     && git checkout $latestTag \


### PR DESCRIPTION
This error prevented the deployment of the Docker container for the latest release (the actual fix result will be available with a bugfix release)

The error was,

```
#12 0.774 Cloning into 'protopipe-grid-interface'...
#12 1.023 fatal: not a git repository (or any of the parent directories): .git
```

caused by the fact that in a Dockerfile is recommended to create first a folder and clone inside of it, but without the destination the folder was already existing and not a git repo